### PR TITLE
Update 3.2-Week 3 Step 2.md

### DIFF
--- a/.bit/responses/3.2-Week 3 Step 2.md
+++ b/.bit/responses/3.2-Week 3 Step 2.md
@@ -176,10 +176,9 @@ var filetype = parsedBody[0].type;
 if (filetype == "image/png") {
     ext = "png";
 } else if (filetype == "image/jpeg") {
-    ext = "jpg";
-} else {
-    username = "invalidimage"
-    ext = "";
+    ext = "jpeg";
+} else if (filetype == "image/jpg") {
+    ext = "jpg"
 }
 ```
 

--- a/.bit/responses/3.2-Week 3 Step 2.md
+++ b/.bit/responses/3.2-Week 3 Step 2.md
@@ -179,6 +179,9 @@ if (filetype == "image/png") {
     ext = "jpeg";
 } else if (filetype == "image/jpg") {
     ext = "jpg"
+} else {
+    username = "invalidimage"
+    ext = "";
 }
 ```
 


### PR DESCRIPTION
Fixed the extension determine code to be this, so that the test file sent by bot will pass the tests. Previously, a .jpeg image would be given the .jpg extension, which failed the tests

```js
if (filetype == "image/png") {
    ext = "png";
} else if (filetype == "image/jpeg") {
    ext = "jpeg";
} else if (filetype == "image/jpg") {
    ext = "jpg"
} else {
    username = "invalidimage"
    ext = "";
}
```

Closes #274 