### PR TITLE
Endpoint wording fix

### DIFF
--- a/.bit/responses/1.4-Week 1 Step 4.md
+++ b/.bit/responses/1.4-Week 1 Step 4.md
@@ -20,7 +20,7 @@ Week 1 Step 4 ⬤⬤⬤⬤◯◯◯◯◯ | 🕐 Estimated completion: 35-45 min
 - [ ] ***2:*** Set up Azure locally on VS Code 
 - [ ] ***3:*** Create an HTTP trigger Azure function that gets content from a request parameter called `password` and returns it in the function's body 
 - [ ] ***4:*** Test your function locally with Postman and, when you confirm that it works, deploy your function 
-- [ ] 🚀 Place your function URL from Azure in a [repository secret](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) called `HACKERVOICE_ENDPOINT` and commit the function's code in a file named `hackervoice/index.js` on the `hackervoice` branch 
+- [ ] 🚀 Place your function URL from the Azure portal in a [repository secret](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) called `HACKERVOICE_ENDPOINT` and commit the function's code in a file named `hackervoice/index.js` on the `hackervoice` branch 
 - [ ] 🚀 Create a pull request that merges `hackervoice` to `main`, but **do not merge it** 
 
 ## 🚧 Test your Work

--- a/.bit/responses/1.4-Week 1 Step 4.md
+++ b/.bit/responses/1.4-Week 1 Step 4.md
@@ -20,7 +20,7 @@ Week 1 Step 4 ⬤⬤⬤⬤◯◯◯◯◯ | 🕐 Estimated completion: 35-45 min
 - [ ] ***2:*** Set up Azure locally on VS Code 
 - [ ] ***3:*** Create an HTTP trigger Azure function that gets content from a request parameter called `password` and returns it in the function's body 
 - [ ] ***4:*** Test your function locally with Postman and, when you confirm that it works, deploy your function 
-- [ ] 🚀 Place your function URL in a [repository secret](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) called `HACKERVOICE_ENDPOINT` and commit the function's code in a file named `hackervoice/index.js` on the `hackervoice` branch 
+- [ ] 🚀 Place your function URL from Azure in a [repository secret](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) called `HACKERVOICE_ENDPOINT` and commit the function's code in a file named `hackervoice/index.js` on the `hackervoice` branch 
 - [ ] 🚀 Create a pull request that merges `hackervoice` to `main`, but **do not merge it** 
 
 ## 🚧 Test your Work


### PR DESCRIPTION
Change from ` Place your function URL in a repository secret called HACKERVOICE_ENDPOINT` to ` Place your function URL from Azure in a repository secret called HACKERVOICE_ENDPOINT`

Closes #279 