### PR TITLE
 specify function auth

### DIFF
--- a/.bit/responses/3.1-Week 3 Step 1.md
+++ b/.bit/responses/3.1-Week 3 Step 1.md
@@ -102,6 +102,8 @@ A **storage account** provides a unique namespace in Azure for your data. **Ever
 
 Create a new HTTP trigger function named `bunnimage-upload` (no need to edit the code yet). Feel free to navigate to the previous issues/steps for guidance if you need extra help. 
 
+> 💡 Make sure to set the auth level as `function` for the HTTP trigger. 
+
 Before we start coding the trigger, we need to install the following `npm` packages/libraries in the Function App we created in the previous step:
 
 1. `parse-multipart`


### PR DESCRIPTION
## Changes made
* Specified they should use`function` as the auth level.

I've always used `function` for the entire curriculum and it's worked for me. 

Closes #338 