### PR TITLE
Basic handling of empty query parameter (Issue #413)

### DIFF
--- a/.bit/tests/sample-solutions/week1/1.4-hackervoice.js
+++ b/.bit/tests/sample-solutions/week1/1.4-hackervoice.js
@@ -1,10 +1,15 @@
 module.exports = async function (context, req) {
+
     context.log('JavaScript HTTP trigger function processed a request.');
-    
-    const password = req.query.password;
+
+    let responseValue = "Provide a value in the query parameter 'Password'.";
+
+    if (req.query.password) {
+        responseValue = req.query.password;
+    }
 
     context.res = {
         // status: 200, /* Defaults to 200 */
-        body: password
+        body: responseValue
     };
 }


### PR DESCRIPTION
## Changes made

This PR contains the code changes to have a basic check of the query parameter (if provided or not and if empty or not) and retuning a corresponding message to the caller

Closes #413