### PR TITLE
Instructions for local.settings.json

### DIFF
--- a/.bit/responses/2.3-Week 2 Step 3.md
+++ b/.bit/responses/2.3-Week 2 Step 3.md
@@ -72,20 +72,27 @@ Follow this [Documentation](https://docs.microsoft.com/en-us/azure/azure-functio
 - [Get started in the Azure portal](https://docs.microsoft.com/en-us/azure/azure-functions/functions-how-to-use-azure-function-app-settings?tabs=portal#get-started-in-the-azure-portal)
 - [Work with application settings](https://docs.microsoft.com/en-us/azure/azure-functions/functions-how-to-use-azure-function-app-settings?tabs=portal#settings)
 
+💡 When you put the key and endpoint in Azure's application settings, **those values are not accessible from the Azure Function running locally.** To make local development easier, Azure Functions Extension creates a file called `local.settings.json` that mimics the application settings and is by default not tracked by git (excluded in .gitignore).
 
-💡 When you put the key and endpoint in Azure's application settings, it will only work after it is deployed and running with the Azure function url. In order to use postman and test this on your computer before deploying to Azure, you will need to code the `subscriptionKey` and `uriBase` like this:
+> **Tip:** You can transfer your application settings from your Function App to your local machine instead of modifying the `local.settings.json` file manually!
+> Fetch the settings via: `func azure functionapp fetch-app-settings '<function-name>' --output-file local.settings.json`
+> Decrypt the settings via: `func settings decrypt`
+
+In order to use Postman and test this on your computer before deploying to Azure, you will need modify the `local.settings.json` file that is automatically created when you create an Azure Function.
 ```js
-const subscriptionKey = "YOUR_SUBSCRIPTIONKEY"
-const uriBase = "YOUR_LOCALHOST_URL"
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "",
+    "FUNCTIONS_WORKER_RUNTIME": "node"
+    "SUBSCRIPTIONKEY" : "your key",
+    "ENDPOINT" : "your endpoint"
+  }
+}
 ```
-💡 Afterwards, when commiting the code to github for the counselorbot to check, you will need to replace the hardcoded `subscriptionKey` and `uriBase` variables with `process.env.SUBSCRIPTIONKEY` and `process.env.ENDPOINT`
+Values that will be kept secret and referenced from your Function App's application settings can be placed in the `Values` object for local development. The local Azure Functions execution runtime then **injects the values from there** to the `process.env` syntax in your code.
 
-<details>
-<summary>❓ Why do we need to do this? </summary>
-</br>
-
-When running your program on your own computer, the program has no way of accessing Microsoft Azure's function application settings, so `process.env` will not work. However, once you deploy the function onto Azure, the function now can "see" the application settings, and can use them through `process.env`
-</details>
+💡 Make sure to use the **correct syntax** for `process.env` to access your secrets! A correct example could be: `process.env['SUBSCRIPTIONKEY']`.
 
 ## 2: Call the FACE API
 

--- a/.bit/responses/2.3-Week 2 Step 3.md
+++ b/.bit/responses/2.3-Week 2 Step 3.md
@@ -63,8 +63,8 @@ The `process.env` object allows you to access super-secret values in your backen
 
 ```js
 async function analyzeImage(img){
-    const subscriptionKey = process.env.SUBSCRIPTIONKEY;
-    const uriBase = process.env.ENDPOINT + '/face/v1.0/detect';
+    const subscriptionKey = process.env["SUBSCRIPTIONKEY"];
+    const uriBase = process.env["ENDPOINT"] + '/face/v1.0/detect';
 }
 ```
 
@@ -92,7 +92,7 @@ In order to use Postman and test this on your computer before deploying to Azure
 ```
 Values that will be kept secret and referenced from your Function App's application settings can be placed in the `Values` object for local development. The local Azure Functions execution runtime then **injects the values from there** to the `process.env` syntax in your code.
 
-💡 Make sure to use the **correct syntax** for `process.env` to access your secrets! A correct example could be: `process.env['SUBSCRIPTIONKEY']`.
+💡 Make sure to use the **correct syntax** for `process.env` to access your secrets! A correct example could be: `process.env["SUBSCRIPTIONKEY"]`.
 
 ## 2: Call the FACE API
 

--- a/.bit/responses/3.2-Week 3 Step 2.md
+++ b/.bit/responses/3.2-Week 3 Step 2.md
@@ -73,7 +73,7 @@ To test your work, you'll be using Postman to send a POST request in Postman wit
 2. Add the following lines of code to the top of your index.js file:
     ```js
     const multipart = require("parse-multipart")
-    const connectionString = process.env.AZURE_STORAGE_CONNECTION_STRING;
+    const connectionString = process.env["AZURE_STORAGE_CONNECTION_STRING"];
     const { BlobServiceClient } = require("@azure/storage-blob");
     ```
     - Take note of the `process.env` value being assigned to `connectionString`. `AZURE_STORAGE_CONNECTION_STRING` is the name of the environment variable. 

--- a/.bit/responses/3.7-Week 3 Step 7.md
+++ b/.bit/responses/3.7-Week 3 Step 7.md
@@ -101,8 +101,8 @@ Here is an example of the config object. Make sure your databaseId, containerId,
 
 ```js
 const config = {
-  endpoint: process.env.COSMOS_ENDPOINT,
-  key: process.env.COSMOS_KEY,
+  endpoint: process.env["COSMOS_ENDPOINT"],
+  key: process.env.["COSMOS_KEY"],
   databaseId: "SecretStorer",
   containerId: "secrets",
   partitionKey: {kind: "Hash", paths: ["/secrets"]}

--- a/.bit/tests/sample-solutions/week3/3.2-bunnimage.js
+++ b/.bit/tests/sample-solutions/week3/3.2-bunnimage.js
@@ -5,7 +5,7 @@ const parseMultipart = require("parse-multipart");
 
 module.exports = async function (context, req) {
 
-    const connectionString = process.env.AZURE_STORAGE_CONNECTION_STRING;
+    const connectionString = process.env["AZURE_STORAGE_CONNECTION_STRING"];
 
     const boundary = parseMultipart.getBoundary(req.headers['content-type']);
     const parsedBody = parseMultipart.Parse(req.body, boundary);

--- a/.bit/tests/sample-solutions/week3/3.3-bunnimage.js
+++ b/.bit/tests/sample-solutions/week3/3.3-bunnimage.js
@@ -6,7 +6,7 @@ const parseMultipart = require("parse-multipart");
 
 module.exports = async function (context, req) {
 
-    const connectionString = process.env.AZURE_STORAGE_CONNECTION_STRING;
+    const connectionString = process.env["AZURE_STORAGE_CONNECTION_STRING"];
 
     /*
     Get the filename via the route defined in function.json 

--- a/.bit/tests/sample-solutions/week3/3.4-bunnimage.js
+++ b/.bit/tests/sample-solutions/week3/3.4-bunnimage.js
@@ -12,7 +12,7 @@ in the local.settings.json file
 
 module.exports = async function (context, myTimer) {
 
-    const connectionString = process.env.AZURE_STORAGE_CONNECTION_STRING;
+    const connectionString = process.env["AZURE_STORAGE_CONNECTION_STRING"];
     const deleteContainerName = "images";
 
     const blobContainerClient = await BlobServiceClient.fromConnectionString(connectionString).getContainerClient(deleteContainerName);

--- a/.bit/tests/sample-solutions/week3/3.8-deepsecrets.js
+++ b/.bit/tests/sample-solutions/week3/3.8-deepsecrets.js
@@ -34,8 +34,8 @@ module.exports = async function (context, req) {
 
 function getCosmosDBConfig() {
     const config = {
-        endpoint: process.env.COSMOSDB_ENDPOINT,
-        key: process.env.COSMOSDB_KEY,
+        endpoint: process.env["COSMOSDB_ENDPOINT"],
+        key: process.env["COSMOSDB_KEY"],
         databaseId: "SecretStorer",
         containerId: "secrets",
         partitionKey: { kind: "Hash", paths: ["/secrets"] }

--- a/.bit/tests/sample-solutions/week3/deepsecrets.js
+++ b/.bit/tests/sample-solutions/week3/deepsecrets.js
@@ -3,8 +3,8 @@ const CosmosClient = require("@azure/cosmos").CosmosClient;
 // npm install @azure/cosmos
 
 const config = {
-  endpoint: process.env.ENDPOINT,
-  key: process.env.KEY,
+  endpoint: process.env["ENDPOINT"],
+  key: process.env["KEY"],
   databaseId: "SecretStorer",
   containerId: "secrets",
   partitionKey: {kind: "Hash", paths: ["/secrets"]}


### PR DESCRIPTION
## Changes made
* Switched out instructions for env secrets/application settings and incorporated `local.settings.json`
* Standardized syntax for secrets (changing `process.env.SECRET` to `process.env["SECRET"]`

Closes #449 
Closes #502 